### PR TITLE
Okay, here's the plan:

### DIFF
--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -10,12 +10,14 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_SERVER REQUIRED wayland-server)
 pkg_check_modules(EGL REQUIRED egl)
 pkg_check_modules(GLESV2 REQUIRED glesv2)
+pkg_check_modules(WAYLAND_EGL REQUIRED wayland-egl)
 
 # Include directories
 include_directories(
     ${WAYLAND_SERVER_INCLUDE_DIRS}
     ${EGL_INCLUDE_DIRS}
     ${GLESV2_INCLUDE_DIRS}
+    ${WAYLAND_EGL_INCLUDE_DIRS}
 )
 
 # Add the compositor stub executable
@@ -27,6 +29,7 @@ target_link_libraries(neurodeck_compositor
     ${WAYLAND_SERVER_LIBRARIES}
     ${EGL_LIBRARIES}
     ${GLESV2_LIBRARIES}
+    ${WAYLAND_EGL_LIBRARIES}
 )
 
 target_compile_options(neurodeck_compositor PRIVATE


### PR DESCRIPTION
fix: Link against wayland-egl to resolve undefined references

The previous commit was missing a linkage dependency on the wayland-egl library, which provides symbols like `wl_egl_window_create` and `wl_egl_window_destroy`.

This commit updates `desktop/CMakeLists.txt` to:
- Use pkg-config to find the `wayland-egl` library.
- Add its include directories to the build.
- Link the `neurodeck_compositor` target against `wayland-egl`.

This should resolve the linker errors encountered when building after the initial EGL/OpenGL integration.